### PR TITLE
49 luo inproceeding entity joka perii reference luokalta

### DIFF
--- a/tests/unit/reference_entity_test.py
+++ b/tests/unit/reference_entity_test.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from viiteri.entities.references import Article, Book
+from viiteri.entities.references import Article, Book, Inproceeding
 
 
 class TestReferenceEntity(unittest.TestCase):
@@ -15,6 +15,9 @@ class TestReferenceEntity(unittest.TestCase):
         self.test_book = Book(cite_key="petkir", author="Petteri",
                               editor="Petteri", title="Petterin Kirja vol 2",
                               publisher="WSOY", year="2004")
+        self.test_inproceeding = Inproceeding(cite_key="johinp", author="John Doe",
+                                              title="An Analysis of Example", booktitle="Sample Text",
+                                              year="2002", editor="Ex Ample")
 
     def test_article_constructor(self):
         """ Test that Article entity is correctly instantiated """
@@ -44,6 +47,21 @@ class TestReferenceEntity(unittest.TestCase):
         self.assertEqual(self.test_book.publisher, "WSOY")
         self.assertEqual(self.test_book.year, "2004")
 
+    def test_inproceeding_constructor(self):
+        """ Test that Inproceeding-entity is correctly instantiated """
+        # Test that abstract fields are set
+        self.assertEqual(self.test_inproceeding.type, "inproceeding")
+        self.assertEqual(self.test_inproceeding.cite_key, "johinp")
+
+        # Test that required fields are set
+        self.assertEqual(self.test_inproceeding.author, "John Doe")
+        self.assertEqual(self.test_inproceeding.title, "An Analysis of Example")
+        self.assertEqual(self.test_inproceeding.booktitle, "Sample Text")
+        self.assertEqual(self.test_inproceeding.year, "2002")
+
+        # Test that optional fields are set
+        self.assertEqual(self.test_inproceeding.editor, "Ex Ample")
+
     def test_init_article_with_missing_required_arguments(self):
         """ Test that Article entity raises ValueError with invalid arguments """
 
@@ -58,6 +76,14 @@ class TestReferenceEntity(unittest.TestCase):
             Book(cite_key="petkir", author="Petteri",
                  editor="Petteri", publisher="WSOY",
                  year="2004")
+
+    def test_init_inproceeding_with_missing_required_arguments(self):
+        """ Test that Inproceeding-entity raises ValueError with invalid arguments  """
+
+        with self.assertRaises(ValueError):
+            Inproceeding(cite_key="johinp", author="John Doe",
+                 title="An Analysis of Example", booktitle="Sample Text",
+                 editor="Ex Ample")
 
     def test_article_str_method(self):
         """ Test that Article entitys str method returns correct string """
@@ -96,3 +122,24 @@ class TestReferenceEntity(unittest.TestCase):
                                     "'doi': None, "
                                     "'issn': None, "
                                     "'isbn': None}"))
+
+    def test_inproceeding_str_method(self):
+        """ Test that Inproceeding entitys str method returns correct string """
+        inproceeding_str = str(self.test_inproceeding)
+        self.assertEqual(inproceeding_str, ("{'_type': 'inproceeding', "
+                                    "'_cite_key': 'johinp', "
+                                    "'author': 'John Doe', "
+                                    "'title': 'An Analysis of Example', "
+                                    "'booktitle': 'Sample Text', "
+                                    "'year': '2002', "
+                                    "'editor': 'Ex Ample', "
+                                    "'volume': None, "
+                                    "'number': None, "
+                                    "'series': None, "
+                                    "'pages': None, "
+                                    "'month': None, "
+                                    "'address': None, "
+                                    "'organization': None, "
+                                    "'publisher': None, "
+                                    "'note': None, "
+                                    "'annote': None}"))

--- a/tests/unit/reference_entity_test.py
+++ b/tests/unit/reference_entity_test.py
@@ -16,7 +16,8 @@ class TestReferenceEntity(unittest.TestCase):
                               editor="Petteri", title="Petterin Kirja vol 2",
                               publisher="WSOY", year="2004")
         self.test_inproceeding = Inproceeding(cite_key="johinp", author="John Doe",
-                                              title="An Analysis of Example", booktitle="Sample Text",
+                                              title="An Analysis of Example",
+                                              booktitle="Sample Text",
                                               year="2002", editor="Ex Ample")
 
     def test_article_constructor(self):
@@ -55,7 +56,8 @@ class TestReferenceEntity(unittest.TestCase):
 
         # Test that required fields are set
         self.assertEqual(self.test_inproceeding.author, "John Doe")
-        self.assertEqual(self.test_inproceeding.title, "An Analysis of Example")
+        self.assertEqual(self.test_inproceeding.title,
+                         "An Analysis of Example")
         self.assertEqual(self.test_inproceeding.booktitle, "Sample Text")
         self.assertEqual(self.test_inproceeding.year, "2002")
 
@@ -82,8 +84,8 @@ class TestReferenceEntity(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             Inproceeding(cite_key="johinp", author="John Doe",
-                 title="An Analysis of Example", booktitle="Sample Text",
-                 editor="Ex Ample")
+                         title="An Analysis of Example", booktitle="Sample Text",
+                         editor="Ex Ample")
 
     def test_article_str_method(self):
         """ Test that Article entitys str method returns correct string """
@@ -127,19 +129,19 @@ class TestReferenceEntity(unittest.TestCase):
         """ Test that Inproceeding entitys str method returns correct string """
         inproceeding_str = str(self.test_inproceeding)
         self.assertEqual(inproceeding_str, ("{'_type': 'inproceeding', "
-                                    "'_cite_key': 'johinp', "
-                                    "'author': 'John Doe', "
-                                    "'title': 'An Analysis of Example', "
-                                    "'booktitle': 'Sample Text', "
-                                    "'year': '2002', "
-                                    "'editor': 'Ex Ample', "
-                                    "'volume': None, "
-                                    "'number': None, "
-                                    "'series': None, "
-                                    "'pages': None, "
-                                    "'month': None, "
-                                    "'address': None, "
-                                    "'organization': None, "
-                                    "'publisher': None, "
-                                    "'note': None, "
-                                    "'annote': None}"))
+                                            "'_cite_key': 'johinp', "
+                                            "'author': 'John Doe', "
+                                            "'title': 'An Analysis of Example', "
+                                            "'booktitle': 'Sample Text', "
+                                            "'year': '2002', "
+                                            "'editor': 'Ex Ample', "
+                                            "'volume': None, "
+                                            "'number': None, "
+                                            "'series': None, "
+                                            "'pages': None, "
+                                            "'month': None, "
+                                            "'address': None, "
+                                            "'organization': None, "
+                                            "'publisher': None, "
+                                            "'note': None, "
+                                            "'annote': None}"))

--- a/tests/unit/reference_repository_test.py
+++ b/tests/unit/reference_repository_test.py
@@ -3,7 +3,7 @@
 import unittest
 
 from viiteri.app import create_app
-from viiteri.entities.references import Article, Book
+from viiteri.entities.references import Article, Book, Inproceeding
 from viiteri.repositories.reference_repository import reference_repository
 
 
@@ -21,20 +21,26 @@ class TestReferenceRepository(unittest.TestCase):
         self.test_book = Book(cite_key="petkir", author="Petteri",
                               editor="Petteri", title="Petterin Kirja vol 2",
                               publisher="WSOY", year="2004")
+        self.test_inproceeding = Inproceeding(cite_key="johinp", author="John Doe",
+                                              title="An Analysis of Example", booktitle="Sample Text",
+                                              year="2002", editor="Ex Ample")
 
     def test_add_reference(self):
         """ Test adding all reference types to the repository """
         reference_repository.add_reference(self.test_article)
         reference_repository.add_reference(self.test_book)
+        reference_repository.add_reference(self.test_inproceeding)
         references = reference_repository.get_all_references()
 
-        self.assertEqual(len(references), 2)
+        self.assertEqual(len(references), 3)
         self.assertEqual(references[0].cite_key, "petpet")
         self.assertEqual(references[1].cite_key, "petkir")
+        self.assertEqual(references[2].cite_key, "johinp")
 
     def test_delete_all_references(self):
         """ Test deleting all references from the repository """
         reference_repository.add_reference(self.test_article)
         reference_repository.add_reference(self.test_book)
+        reference_repository.add_reference(self.test_inproceeding)
         reference_repository.delete_all()
         self.assertEqual(len(reference_repository.get_all_references()), 0)

--- a/tests/unit/reference_service_test.py
+++ b/tests/unit/reference_service_test.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from viiteri.entities.references import Article, Book
+from viiteri.entities.references import Article, Book, Inproceeding
 from viiteri.services.reference_service import ReferenceService
 
 
@@ -15,7 +15,10 @@ class ReferenceRepositoryStub:
                                     journal="Petterin Kirjakokoelma", year="2003"),
                             Book(cite_key="petkir", author="Petteri", 
                                  editor="Petteri", title="Petterin Kirja vol 2", 
-                                 publisher="WSOY", year="2004")]
+                                 publisher="WSOY", year="2004"),
+                            Inproceeding(cite_key="johinp", author="John Doe",
+                                         title="An Analysis of Example", booktitle="Sample Text",
+                                         year="2002", editor="Ex Ample")]
 
     def get_all_references(self):
         """ Returns all references """
@@ -38,9 +41,10 @@ class TestReferenceService(unittest.TestCase):
 
         references = self.reference_service.get_all_references()
 
-        self.assertEqual(len(references), 2)
+        self.assertEqual(len(references), 3)
         self.assertEqual(references[0].cite_key, "petpet")
         self.assertEqual(references[1].cite_key, "petkir")
+        self.assertEqual(references[2].cite_key, "johinp")
 
     def test_create_reference(self):
         """ Test that create_reference returns a valid bibtex string """
@@ -59,6 +63,14 @@ class TestReferenceService(unittest.TestCase):
                                                               year="2007",
                                                               publisher="Addison-Wesley",
                                                               editor="editor")
+        result_inproceeding = self.reference_service.create_reference("inproceeding",
+                                                                      cite_key="johinp",
+                                                                      author="John Doe",
+                                                                      title="An Analysis of Example",
+                                                                      booktitle="Sample Text",
+                                                                      year="2002",
+                                                                      editor="Ex Ample")
 
         self.assertEqual(result_article.cite_key, "zimmerman2002becoming")
         self.assertEqual(result_book.cite_key, "CI")
+        self.assertEqual(result_inproceeding.cite_key, "johinp")

--- a/viiteri/entities/references/__init__.py
+++ b/viiteri/entities/references/__init__.py
@@ -2,3 +2,4 @@
 from viiteri.entities.references.reference import Reference
 from viiteri.entities.references.article import Article
 from viiteri.entities.references.book import Book
+from viiteri.entities.references.inproceeding import Inproceeding

--- a/viiteri/entities/references/inproceeding.py
+++ b/viiteri/entities/references/inproceeding.py
@@ -1,0 +1,31 @@
+""" viiteri/entities/references/inproceeding.py """
+
+# pylint: disable=too-many-instance-attributes
+from viiteri.entities.references import Reference
+
+
+class Inproceeding(Reference):
+    """ Class for representing 'inproceeding'-type references """
+
+    def __init__(self, **kwargs):
+        if not kwargs.keys() >= {"cite_key", "author", "title", "booktitle", "year"}:
+            raise ValueError("Missing required arguments")
+
+        super().__init__("inproceeding", kwargs["cite_key"])
+        self.author = kwargs["author"]
+        self.title = kwargs["title"]
+        self.booktitle = kwargs["booktitle"]
+        self.year = kwargs["year"]
+
+        # Optional arguments
+        self.editor = kwargs.get("editor", None)
+        self.volume = kwargs.get("volume", None)
+        self.number = kwargs.get("number", None)
+        self.series = kwargs.get("series", None)
+        self.pages = kwargs.get("pages", None)
+        self.month = kwargs.get("month", None)
+        self.address = kwargs.get("address", None)
+        self.organization = kwargs.get("organization", None)
+        self.publisher = kwargs.get("publisher", None)
+        self.note = kwargs.get("note", None)
+        self.annote = kwargs.get("annote", None)

--- a/viiteri/utils/reference_factory.py
+++ b/viiteri/utils/reference_factory.py
@@ -1,6 +1,6 @@
 """ viiteri/utils/reference_factory.py """
 
-from viiteri.entities.references import Article, Book
+from viiteri.entities.references import Article, Book, Inproceeding
 
 
 class ReferenceFactory:
@@ -13,6 +13,8 @@ class ReferenceFactory:
                 return Article(**kwargs)
             case "book":
                 return Book(**kwargs)
+            case "inproceeding":
+                return Inproceeding(**kwargs)
 
         raise ValueError("Unknown reference type")
 


### PR DESCRIPTION
- Lisätty inproceeding-entity
  - Lisätty inproceeding.py tiedosto johon Inproceeding-luokka
  - Lisätty inproceeding-luokka \__init__.py -tiedostoon
  - Lisätty inproceeding-case ReferenceFactoryyn
- Lisätty reference_entity, reference_service ja reference_repository -testit inproceeding-entitylle