### PR TITLE
45 luo jokaiselle reference rajapinnan perivälle entitylle ieee metodi joka palauttaa ieee muodossa olevan merkkijonon

### DIFF
--- a/tests/unit/reference_entity_test.py
+++ b/tests/unit/reference_entity_test.py
@@ -151,15 +151,36 @@ class TestReferenceEntity(unittest.TestCase):
     def test_article_format_ieee(self):
         """Article entity is correctly converted to IEEE format"""
         article_ieee = 'Petteri, Petterin Kirja, Petterin Kirjakokoelma, 1, 2003'
+
+        article_entity = Article(cite_key="petpet", author="Petteri Petterinpoika",
+                                    title="Petterin Kirja",
+                                    journal="Petterin Kirjakokoelma", year="2003", volume="1")
+        another_article_ieee = 'P. Petterinpoika, Petterin Kirja, Petterin Kirjakokoelma, 1, 2003'
+
         self.assertEqual(article_ieee, self.test_article.format_ieee())
+        self.assertEqual(another_article_ieee, article_entity.format_ieee())
 
     def test_book_format_ieee(self):
         """Book entity is correctly converted to IEEE format"""
         book_ieee = 'Petteri, Ed. Petterin Kirja vol 2, WSOY, 2004'
+
+        book_entity = Book(cite_key="petkir", author="Petteri Petterinpoika", editor="Petteri",
+                           title="Petterin Kirja vol 2", publisher="WSOY", year="2004")
+        another_book_ieee = 'P. Petterinpoika, Petterin Kirja vol 2, Petteri, WSOY, 2004'
+
         self.assertEqual(book_ieee, self.test_book.format_ieee())
+        self.assertEqual(another_book_ieee, book_entity.format_ieee())
 
     def test_inproceeding_format_ieee(self):
         """Inproceeding entity is correctly converted to IEEE format"""
         inproceeding_ieee = 'J. Doe, An Analysis of Example, Sample Text, Ex Ample, 2002'
+
+        inp_entity = Inproceeding(cite_key="johinp", author="Doe",
+                                  title="An Analysis of Example",
+                                  booktitle="Sample Text",
+                                  year="2002", editor="Ex Ample")
+        inp_ieee_surname_only = 'Doe, An Analysis of Example, Sample Text, Ex Ample, 2002'
+
         self.assertEqual(inproceeding_ieee, self.test_inproceeding.format_ieee())
+        self.assertEqual(inp_ieee_surname_only, inp_entity.format_ieee())
     

--- a/tests/unit/reference_entity_test.py
+++ b/tests/unit/reference_entity_test.py
@@ -145,3 +145,21 @@ class TestReferenceEntity(unittest.TestCase):
                                             "'publisher': None, "
                                             "'note': None, "
                                             "'annote': None}"))
+
+    # ieee format tests:
+
+    def test_article_format_ieee(self):
+        """Article entity is correctly converted to IEEE format"""
+        article_ieee = 'Petteri, Petterin Kirja, Petterin Kirjakokoelma, 1, 2003'
+        self.assertEqual(article_ieee, self.test_article.format_ieee())
+
+    def test_book_format_ieee(self):
+        """Book entity is correctly converted to IEEE format"""
+        book_ieee = 'Petteri, Ed. Petterin Kirja vol 2, WSOY, 2004'
+        self.assertEqual(book_ieee, self.test_book.format_ieee())
+
+    def test_inproceeding_format_ieee(self):
+        """Inproceeding entity is correctly converted to IEEE format"""
+        inproceeding_ieee = 'J. Doe, An Analysis of Example, Sample Text, Ex Ample, 2002'
+        self.assertEqual(inproceeding_ieee, self.test_inproceeding.format_ieee())
+    

--- a/viiteri/entities/references/article.py
+++ b/viiteri/entities/references/article.py
@@ -27,3 +27,17 @@ class Article(Reference):
         self.issn = kwargs.get("issn", None)
         self.zblnumber = kwargs.get("zblnumber", None)
         self.eprint = kwargs.get("eprint", None)
+
+    def format_ieee(self):
+        """Returns the reference in IEEE format"""
+        author = self.author.split(' ')
+        reference = f"{self.author}, "
+        if len(author) > 1:
+            reference = f"{author[0][0]}. {author[1]}"
+
+        fields = [self.title, self.journal, self.volume, self.number,
+                  self.pages, self.month, self.year, self.doi]
+
+        reference += ', '.join(field for field in fields if field)
+
+        return reference

--- a/viiteri/entities/references/article.py
+++ b/viiteri/entities/references/article.py
@@ -33,7 +33,7 @@ class Article(Reference):
         author = self.author.split(' ')
         reference = f"{self.author}, "
         if len(author) > 1:
-            reference = f"{author[0][0]}. {author[1]}"
+            reference = f"{author[0][0]}. {author[1]}, "
 
         fields = [self.title, self.journal, self.volume, self.number,
                   self.pages, self.month, self.year, self.doi]

--- a/viiteri/entities/references/book.py
+++ b/viiteri/entities/references/book.py
@@ -27,3 +27,19 @@ class Book(Reference):
         self.doi = kwargs.get("doi", None)
         self.issn = kwargs.get("issn", None)
         self.isbn = kwargs.get("isbn", None)
+
+    def format_ieee(self):
+        """Returns the reference in IEEE format"""
+        author = self.author.split(' ')
+        reference = f"{self.author}, "
+        if len(author) > 1:
+            reference = f"{author[0][0]}. {author[1]}"
+
+        fields = [self.title, self.editor, self.publisher, self.year, self.pages]
+        if self.author == self.editor:
+            reference += "Ed. "
+            fields.remove(self.editor)
+
+        reference += ', '.join(field for field in fields if field)
+
+        return reference

--- a/viiteri/entities/references/book.py
+++ b/viiteri/entities/references/book.py
@@ -33,7 +33,7 @@ class Book(Reference):
         author = self.author.split(' ')
         reference = f"{self.author}, "
         if len(author) > 1:
-            reference = f"{author[0][0]}. {author[1]}"
+            reference = f"{author[0][0]}. {author[1]}, "
 
         fields = [self.title, self.editor, self.publisher, self.year, self.pages]
         if self.author == self.editor:

--- a/viiteri/entities/references/inproceeding.py
+++ b/viiteri/entities/references/inproceeding.py
@@ -29,3 +29,17 @@ class Inproceeding(Reference):
         self.publisher = kwargs.get("publisher", None)
         self.note = kwargs.get("note", None)
         self.annote = kwargs.get("annote", None)
+
+    def format_ieee(self):
+        """Returns the reference in IEEE format"""
+        author = self.author.split(' ')
+        reference = f"{self.author}, "
+        if len(author) > 1:
+            reference = f"{author[0][0]}. {author[1]}, "
+
+        fields = [self.title, self.booktitle, self.volume, self.series,
+                  self.editor, self.month, self.year, self.pages]
+
+        reference += ', '.join(field for field in fields if field)
+
+        return reference

--- a/viiteri/entities/references/reference.py
+++ b/viiteri/entities/references/reference.py
@@ -1,5 +1,5 @@
 """ viiteri/entities/references/reference.py """
-from abc import ABC
+from abc import ABC, abstractmethod
 
 
 class Reference(ABC):
@@ -12,9 +12,9 @@ class Reference(ABC):
     def __str__(self):
         return str(self.__dict__)
 
-    # @abstractmethod
-    # def format_ieee(self):
-    #    """ Return IEEE formatted reference """
+    @abstractmethod
+    def format_ieee(self):
+       """ Return IEEE formatted reference """
 
     # @abstractmethod
     # def format_bibtex(self):

--- a/viiteri/entities/references/reference.py
+++ b/viiteri/entities/references/reference.py
@@ -14,7 +14,7 @@ class Reference(ABC):
 
     @abstractmethod
     def format_ieee(self):
-       """ Return IEEE formatted reference """
+        """ Return IEEE formatted reference """
 
     # @abstractmethod
     # def format_bibtex(self):


### PR DESCRIPTION
en saanu kaikista lähdeviitteiden kentistä kiinni mut tein alustavasti sen mukaan miten tääl [ieee guides](https://ieeeauthorcenter.ieee.org/wp-content/uploads/IEEE-Reference-Guide.pdf) oli